### PR TITLE
Removed duplicated 'permissions' from models.py. (Fixed #49)

### DIFF
--- a/openslides_votecollector/access_permissions.py
+++ b/openslides_votecollector/access_permissions.py
@@ -9,7 +9,7 @@ class VoteCollectorAccessPermissions(BaseAccessPermissions):
         """
         Returns True if the user has VoteCollector access.
         """
-        return user.has_perm('openslides_votecollector.can_manage_votecollector')
+        return user.has_perm('openslides_votecollector.can_manage')
 
     def get_serializer_class(self, user=None):
         """
@@ -28,7 +28,7 @@ class SeatAccessPermissions(BaseAccessPermissions):
         """
         Returns True if the user has VoteCollector access.
         """
-        return user.has_perm('openslides_votecollector.can_manage_votecollector')
+        return user.has_perm('openslides_votecollector.can_manage')
 
     def get_serializer_class(self, user=None):
         """
@@ -47,7 +47,7 @@ class KeypadAccessPermissions(BaseAccessPermissions):
         """
         Returns True if the user has VoteCollector access.
         """
-        return user.has_perm('openslides_votecollector.can_manage_votecollector')
+        return user.has_perm('openslides_votecollector.can_manage')
 
     def get_serializer_class(self, user=None):
         """
@@ -66,7 +66,7 @@ class MotionPollKeypadConnectionAccessPermissions(BaseAccessPermissions):
         """
         Returns True if the user has VoteCollector access.
         """
-        return user.has_perm('openslides_votecollector.can_manage_votecollector')
+        return user.has_perm('openslides_votecollector.can_manage')
 
     def get_serializer_class(self, user=None):
         """
@@ -85,7 +85,7 @@ class AssignmentPollKeypadConnectionAccessPermissions(BaseAccessPermissions):
         """
         Returns True if the user has VoteCollector access.
         """
-        return user.has_perm('openslides_votecollector.can_manage_votecollector')
+        return user.has_perm('openslides_votecollector.can_manage')
 
     def get_serializer_class(self, user=None):
         """

--- a/openslides_votecollector/migrations/0001_initial.py
+++ b/openslides_votecollector/migrations/0001_initial.py
@@ -54,7 +54,6 @@ class Migration(migrations.Migration):
                 ('in_range', models.BooleanField(default=False)),
             ],
             options={
-                'permissions': (('can_manage_votecollector', 'Can manage VoteCollector'),),
                 'default_permissions': (),
             },
             bases=(openslides.utils.models.RESTModelMixin, models.Model),

--- a/openslides_votecollector/migrations/0001_initial.py
+++ b/openslides_votecollector/migrations/0001_initial.py
@@ -99,7 +99,7 @@ class Migration(migrations.Migration):
                 ('is_voting', models.BooleanField(default=False)),
             ],
             options={
-                'permissions': (('can_manage_votecollector', 'Can manage VoteCollector'),),
+                'permissions': (('can_manage', 'Can manage VoteCollector'),),
                 'default_permissions': (),
             },
             bases=(openslides.utils.models.RESTModelMixin, models.Model),

--- a/openslides_votecollector/models.py
+++ b/openslides_votecollector/models.py
@@ -43,7 +43,7 @@ class VoteCollector(RESTModelMixin, models.Model):
     class Meta:
         default_permissions = ()
         permissions = (
-            ('can_manage_votecollector', 'Can manage VoteCollector'),
+            ('can_manage', 'Can manage VoteCollector'),
         )
 
     def __str__(self):

--- a/openslides_votecollector/models.py
+++ b/openslides_votecollector/models.py
@@ -100,9 +100,6 @@ class Keypad(RESTModelMixin, models.Model):
 
     class Meta:
         default_permissions = ()
-        permissions = (
-            ('can_manage_votecollector', 'Can manage VoteCollector'),
-        )
 
     def __str__(self):
         if self.user is not None:

--- a/openslides_votecollector/signals.py
+++ b/openslides_votecollector/signals.py
@@ -11,7 +11,7 @@ def add_permissions_to_builtin_groups(**kwargs):
     """
     Adds the permissions openslides_votecollector.can_manage_votecollector to the group staff.
     """
-    content_type = ContentType.objects.get(app_label='openslides_votecollector', model='keypad')
+    content_type = ContentType.objects.get(app_label='openslides_votecollector', model='votecollector')
 
     try:
         # Group with pk == 3 should be the staff group in OpenSlides 2.1

--- a/openslides_votecollector/signals.py
+++ b/openslides_votecollector/signals.py
@@ -9,7 +9,7 @@ from .seating_plan import setup_default_plan
 
 def add_permissions_to_builtin_groups(**kwargs):
     """
-    Adds the permissions openslides_votecollector.can_manage_votecollector to the group staff.
+    Adds the permissions openslides_votecollector.can_manage to the group staff.
     """
     content_type = ContentType.objects.get(app_label='openslides_votecollector', model='votecollector')
 
@@ -19,7 +19,7 @@ def add_permissions_to_builtin_groups(**kwargs):
     except Group.DoesNotExist:
         pass
     else:
-        perm_can_manage = Permission.objects.get(content_type=content_type, codename='can_manage_votecollector')
+        perm_can_manage = Permission.objects.get(content_type=content_type, codename='can_manage')
         staff.permissions.add(perm_can_manage)
 
 

--- a/openslides_votecollector/static/js/openslides_votecollector/site.js
+++ b/openslides_votecollector/static/js/openslides_votecollector/site.js
@@ -15,7 +15,7 @@ angular.module('OpenSlidesApp.openslides_votecollector.site', [
             'img_class': 'wifi',
             'title': 'VoteCollector',
             'weight': 700,
-            'perm': 'openslides_votecollector.can_manage_votecollector',
+            'perm': 'openslides_votecollector.can_manage',
         });
     }
 ])

--- a/openslides_votecollector/static/templates/openslides_votecollector/assignmentpoll-detail.html
+++ b/openslides_votecollector/static/templates/openslides_votecollector/assignmentpoll-detail.html
@@ -20,7 +20,7 @@
         <translate>Election</translate>
       </a>
       <!-- Anonymize -->
-      <a os-perms="openslides_votecollector.can_manage_votecollector"
+      <a os-perms="openslides_votecollector.can_manage"
         class="btn btn-sm btn-default"
         ng-bootbox-confirm="{{ 'Are you sure you want to anonymize all votes?' | translate }}"
         ng-bootbox-confirm-action="anonymizeVotes()">

--- a/openslides_votecollector/static/templates/openslides_votecollector/motionpoll-detail.html
+++ b/openslides_votecollector/static/templates/openslides_votecollector/motionpoll-detail.html
@@ -20,7 +20,7 @@
         <translate>Motion</translate>
       </a>
       <!-- Anonymize -->
-      <a os-perms="openslides_votecollector.can_manage_votecollector"
+      <a os-perms="openslides_votecollector.can_manage"
         class="btn btn-sm btn-default"
         ng-bootbox-confirm="{{ 'Are you sure you want to anonymize all votes?' | translate }}"
         ng-bootbox-confirm-action="anonymizeVotes()">

--- a/openslides_votecollector/views.py
+++ b/openslides_votecollector/views.py
@@ -92,7 +92,7 @@ class VotecollectorViewSet(ModelViewSet):
     queryset = VoteCollector.objects.all()
 
     def check_view_permissions(self):
-        return self.request.user.has_perm('openslides_votecollector.can_manage_votecollector')
+        return self.request.user.has_perm('openslides_votecollector.can_manage')
 
 
 class SeatViewSet(ModelViewSet):


### PR DESCRIPTION

@normanjaeckel I removed one of the two 'permissions' and tested it again (see https://github.com/OpenSlides/OpenSlides/issues/2901) - same error:

**django.contrib.auth.models.MultipleObjectsReturned: get() returned more than one Permission -- it returned 2!**